### PR TITLE
Fix media queries

### DIFF
--- a/_assets/css/components/_button.scss
+++ b/_assets/css/components/_button.scss
@@ -1,6 +1,20 @@
 .button {
   font-weight: 500;
   text-transform: none;
+  font-size: 1.3rem;
+  padding: 0.2rem .5rem;
+  @media only screen and (min-width: $mobile) {
+    font-size: 1.4rem;
+    padding: 0.3rem 1rem;
+  }
+  @media only screen and (min-width: $tablet) {
+    font-size: 1.5rem;
+    padding: 0.4rem 1.5rem;
+  }
+  @media only screen and (min-width: $desktop) {
+    font-size: 1.6rem;
+    padding: 0.65rem 3rem;
+  }
 
   &_blue {
     background-color: $blue-600;

--- a/_assets/css/sections/_footer.scss
+++ b/_assets/css/sections/_footer.scss
@@ -9,12 +9,21 @@
   }
 
   &__copy {
-    font-size: 2rem;
     font-weight: 200;
     line-height: 1.4;
     color: $grey-400;
     display: inline-block;
     margin-top: 10px;
+    font-size: 1rem;
+    @media only screen and (min-width: $mobile) {
+      font-size: 1.1rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      font-size: 1.2rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 1.4rem;
+    }
   }
 
   &__nav {

--- a/_assets/css/sections/_footer.scss
+++ b/_assets/css/sections/_footer.scss
@@ -3,13 +3,13 @@
   padding-top: 5vw;
 
   &__logo {
-    font-size: 2vw;
+    font-size: 2rem;
     font-weight: 600;
     line-height: 1.4;
   }
 
   &__copy {
-    font-size: 2vw;
+    font-size: 2rem;
     font-weight: 200;
     line-height: 1.4;
     color: $grey-400;

--- a/_assets/css/sections/_header.scss
+++ b/_assets/css/sections/_header.scss
@@ -1,20 +1,35 @@
 .header {
   box-shadow: 0 1px 2px 0 rgba(60,64,67,.3), 0 2px 6px 2px rgba(60,64,67,.15);
 
-  &__logo {
-    font-size: 1.75vw;
-    font-weight: 600;
+  &__content {
+    margin: 0 auto;
   }
 
-  &__navs {
-    height: 100%;
+  &__logo {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin: 0 auto;
+
+    @media only screen and (min-width: $mobile) {
+      font-size: 1.1rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      margin: 0;
+      font-size: 1.25rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 1.75rem;
+    }
   }
 
   &__nav {
-    font-size: 16px;
-    height: 100%;
+    font-size: 0.9rem;
+
+    @media only screen and (min-width: $tablet) {
+      font-size: 1rem;
+    }
+
     display: inline-block;
-    line-height: $header-content-height;
     padding: 0 15px;
 
     &:hover {

--- a/_assets/css/sections/_hero.scss
+++ b/_assets/css/sections/_hero.scss
@@ -1,14 +1,44 @@
 .hero {
+  padding-top: 2rem;
+  @media only screen and (min-width: $mobile) {
+    font-size: 2.5rem;
+  }
+  @media only screen and (min-width: $tablet) {
+    font-size: 3rem;
+  }
+  @media only screen and (min-width: $desktop) {
+    font-size: 3.5rem;
+  }
+
   &__title {
-    font-size: 2rem;
+    font-size: 1.8rem;
+    margin-bottom: 2rem;
+    @media only screen and (min-width: $mobile) {
+      font-size: 2rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      font-size: 2.75rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 3.5rem;
+    }
     font-weight: 550;
     line-height: 1.4;
     max-width: 100%;
   }
 
   &__subtitle {
-    font-size: 1.5rem;
     font-weight: 300;
-    margin-top: 3vw;
+    margin-bottom: 2rem;
+    font-size: 1.3rem;
+    @media only screen and (min-width: $mobile) {
+      font-size: 1.4rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      font-size: 1.5rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 1.6rem;
+    }
   }
 }

--- a/_assets/css/sections/_hero.scss
+++ b/_assets/css/sections/_hero.scss
@@ -1,13 +1,13 @@
 .hero {
   &__title {
-    font-size: 2vw;
+    font-size: 2rem;
     font-weight: 550;
     line-height: 1.4;
     max-width: 100%;
   }
 
   &__subtitle {
-    font-size: 1.5vw;
+    font-size: 1.5rem;
     font-weight: 300;
     margin-top: 3vw;
   }

--- a/_assets/css/sections/_hero.scss
+++ b/_assets/css/sections/_hero.scss
@@ -1,13 +1,13 @@
 .hero {
   padding-top: 2rem;
   @media only screen and (min-width: $mobile) {
-    font-size: 2.5rem;
+    padding-top: 2.5rem;
   }
   @media only screen and (min-width: $tablet) {
-    font-size: 3rem;
+    padding-top: 3rem;
   }
   @media only screen and (min-width: $desktop) {
-    font-size: 3.5rem;
+    padding-top: 5.5rem;
   }
 
   &__title {

--- a/_assets/css/sections/_options.scss
+++ b/_assets/css/sections/_options.scss
@@ -7,7 +7,7 @@
   }
 
   &__text {
-    font-size: 2.5vw;
+    font-size: 2.5rem;
     font-weight: 300;
     margin-top: 3px;
   }
@@ -21,7 +21,7 @@
   }
 
   &__subtitle {
-    font-size: 4vw;
+    font-size: 4rem;
     font-weight: 600;
   }
 

--- a/_assets/css/sections/_thumb-cta.scss
+++ b/_assets/css/sections/_thumb-cta.scss
@@ -16,14 +16,14 @@
   }
 
  &__title {
-    font-size: 1.8vw;
+    font-size: 1.8rem;
     font-weight: 500;
     line-height: 1.8;
-    margin-top: 2vw;
+    margin-top: 2rem;
   }
 
   &__text {
-    font-size: 1.5vw;
+    font-size: 1.5rem;
     font-weight: 300;
     line-height: 1.8;
     margin-top: 3px;
@@ -36,7 +36,7 @@
   }
 
   &__actions {
-    font-size: 2.5vw;
+    font-size: 2.5rem;
     margin-top: 4vw;
   }
 }

--- a/_assets/css/sections/_thumb-cta.scss
+++ b/_assets/css/sections/_thumb-cta.scss
@@ -16,17 +16,37 @@
   }
 
  &__title {
-    font-size: 1.8rem;
-    font-weight: 500;
-    line-height: 1.8;
-    margin-top: 2rem;
+   font-weight: 500;
+   line-height: 1.8;
+   font-size: 1.5rem;
+    @media only screen and (min-width: $mobile) {
+      font-size: 1.8rem;
+      margin-bottom: 1rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      font-size: 2.5rem;
+      margin-bottom: 1.5rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 3rem;
+      margin-bottom: 2rem;
+    }
   }
 
   &__text {
-    font-size: 1.5rem;
     font-weight: 300;
     line-height: 1.8;
     margin-top: 3px;
+    font-size: 1.3rem;
+    @media only screen and (min-width: $mobile) {
+      font-size: 1.4rem;
+    }
+    @media only screen and (min-width: $tablet) {
+      font-size: 1.5rem;
+    }
+    @media only screen and (min-width: $desktop) {
+      font-size: 1.6rem;
+    }
   }
 
   &__box {
@@ -37,7 +57,6 @@
 
   &__actions {
     font-size: 2.5rem;
-    margin-top: 4vw;
   }
 }
 

--- a/_assets/css/utils/_settings.scss
+++ b/_assets/css/utils/_settings.scss
@@ -20,5 +20,6 @@ $padding-vertical: 5vw;
 $button-md-padding: 0.75vw 3vw;
 $button-md-font-size: 1.5rem;
 
+$mobile: 450px;
 $tablet: 768px;
 $desktop: 980px;

--- a/_assets/css/utils/_settings.scss
+++ b/_assets/css/utils/_settings.scss
@@ -2,9 +2,6 @@ $page-font-size: 14px;
 $page-color: $black;
 $page-font-family: "Roboto", Helvetica Neue, Helvetica, Arial, sans-serif;
 
-$section-content-max-width: 63rem;
-$section-content-small-max-width: 75vw;
-
 $section-title-line-height: 1.2;
 
 $section-subtitle-font-size: 30px;

--- a/_assets/css/utils/_settings.scss
+++ b/_assets/css/utils/_settings.scss
@@ -2,9 +2,7 @@ $page-font-size: 14px;
 $page-color: $black;
 $page-font-family: "Roboto", Helvetica Neue, Helvetica, Arial, sans-serif;
 
-$header-content-height: 5vw;
-
-$section-content-max-width: 90vw;
+$section-content-max-width: 63rem;
 $section-content-small-max-width: 75vw;
 
 $section-title-line-height: 1.2;
@@ -20,4 +18,7 @@ $top-margins: [40];
 $padding-vertical: 5vw;
 
 $button-md-padding: 0.75vw 3vw;
-$button-md-font-size: 1.5vw;
+$button-md-font-size: 1.5rem;
+
+$tablet: 768px;
+$desktop: 980px;

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,21 +1,22 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <title>{{ page.title | default: site.title }}</title>
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700,900" rel="stylesheet">
-    {% css 'main' %}
-  </head>
-  <body class="page">
-    {% include header.html %}
-    <main>
-      <div style="max-width: 80vw; margin: 0 auto;">
-      {{ content }}
-      <div>
-    </main>
-    {% include footer.html %}
-    {% js 'vendor' %}
-    {% js 'index' %}
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+  <title>{{ page.title | default: site.title }}</title>
+  <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,100,500,700,900" rel="stylesheet">
+  {% css 'main' %}
+</head>
+
+<body class="page">
+  {% include header.html %}
+  <main>
+    {{ content }}
+  </main>
+  {% include footer.html %}
+  {% js 'vendor' %}
+  {% js 'index' %}
+</body>
+
 </html>


### PR DESCRIPTION
Removes use of `vw` font sizing and spacing and replaces it with media query breakpoints.
Also tidy up a few bits my linter complained about
and default to using the framework's spacing where possible.

Run by:
```
git checkout fix-media-queries
bundle exec npm run serve
```

Visit [http://127.0.0.1:4000/](http://127.0.0.1:4000/)

Turn on responsive design mode ([firefox](https://developer.mozilla.org/en-US/docs/Tools/Responsive_Design_Mode)) ([chrome](https://developers.google.com/web/tools/chrome-devtools/device-mode/))

and check out the sizing/spacing at various presets or drag around

If you are happy merge, otherwise shout!